### PR TITLE
updates syr to take dynamic values for bundles and resourceS

### DIFF
--- a/ios/SyrNative/SyrNative/SyrBridge.h
+++ b/ios/SyrNative/SyrNative/SyrBridge.h
@@ -11,7 +11,9 @@
 #import "SyrRootView.h"
 
 @interface SyrBridge : NSObject <WKScriptMessageHandler, WKNavigationDelegate>
+@property (nonatomic)  NSString* resourceBundlePath;
 - (void) loadBundle: (NSString*) withBundlePath withRootView: (SyrRootView*) rootView;
+- (void) loadBundle:(NSString*)withBundlePath withRootView: (SyrRootView*)rootView withResourceBundlePath: (NSString*) resourceBundlePath;
 - (void) rasterRenderedComponent: (NSString*) withComponentId;
 - (void) rasterRemovedComponent: (NSString*) withComponentId;
 - (void) sendEvent: (NSDictionary*) message;

--- a/ios/SyrNative/SyrNative/SyrBridge.m
+++ b/ios/SyrNative/SyrNative/SyrBridge.m
@@ -77,23 +77,13 @@
   // todo multiplex bridge : multiple apps, one instance
    _rootView = rootView;
   
-// todo: lets abstract this out to the bundle manager
-// NSBundle* frameworkBundle = [NSBundle bundleForClass:[SyrBridge class]];
-// NSString* syrBundlePath = [frameworkBundle pathForResource:@"SyrNative" ofType:@"bundle"];
-// NSBundle* syrBundle = [NSBundle bundleWithPath:syrBundlePath];
-// NSString* syrBridgePath = [syrBundle pathForResource:@"app" ofType:@"html"];
-  
-  [_bridgedBrowser.configuration.preferences setValue:@TRUE forKey:@"allowFileAccessFromFileURLs"];
-
-#if DEBUG
-  NSURL* syrBridgeUrl = [NSURL URLWithString:@"http://localhost:8080"];
-#else
-  NSBundle* mainBundle = [NSBundle mainBundle];
-  NSString* pyplBundlePath = [mainBundle pathForResource:@"PYPLCheckout" ofType:@"bundle"];
-  NSBundle* pyplBundle = [NSBundle bundleWithPath:pyplBundlePath];
-  NSString* filePath = [pyplBundle pathForResource:@"syrBundle" ofType:@"html"];
-  NSURL* syrBridgeUrl = [NSURL fileURLWithPath:filePath];
-#endif
+  NSURL* syrBridgeUrl;
+  if([withBundlePath containsString:@"http"]) {
+    syrBridgeUrl = [NSURL URLWithString:withBundlePath];
+  } else {
+    [_bridgedBrowser.configuration.preferences setValue:@TRUE forKey:@"allowFileAccessFromFileURLs"];
+    syrBridgeUrl = [NSURL fileURLWithPath:withBundlePath];
+  }
 
   NSURLComponents *components = [NSURLComponents componentsWithURL:syrBridgeUrl resolvingAgainstBaseURL:YES];
   NSMutableArray* exportedMethods = [[NSMutableArray alloc] init];
@@ -144,6 +134,9 @@
                                   repeats:YES];
 }
 
+-(NSString*) resourceBundlePath{
+  return _rootView.resourceBundlePath;
+}
 
 - (void) heartBeat {
   NSString* js = [NSString stringWithFormat:@""];

--- a/ios/SyrNative/SyrNative/SyrImage.m
+++ b/ios/SyrNative/SyrNative/SyrImage.m
@@ -27,6 +27,11 @@ SYR_EXPORT_MODULE(Image)
     image = [[UIImage alloc] initWithData:data];
   } else {
     image = [UIImage imageNamed:source];
+    if(image == nil) {
+      NSString* resourceBundlePath = [[[SyrRaster sharedInstance] bridge] resourceBundlePath];
+      NSBundle* pyplbundle = [[NSBundle alloc] initWithPath:resourceBundlePath];
+      image = [UIImage imageNamed:source inBundle:pyplbundle compatibleWithTraitCollection:nil];
+    }
   }
 
   if(componentInstance != nil) {

--- a/ios/SyrNative/SyrNative/SyrImage.m
+++ b/ios/SyrNative/SyrNative/SyrImage.m
@@ -29,8 +29,8 @@ SYR_EXPORT_MODULE(Image)
     image = [UIImage imageNamed:source];
     if(image == nil) {
       NSString* resourceBundlePath = [[[SyrRaster sharedInstance] bridge] resourceBundlePath];
-      NSBundle* pyplbundle = [[NSBundle alloc] initWithPath:resourceBundlePath];
-      image = [UIImage imageNamed:source inBundle:pyplbundle compatibleWithTraitCollection:nil];
+      NSBundle* bundle = [[NSBundle alloc] initWithPath:resourceBundlePath];
+      image = [UIImage imageNamed:source inBundle:bundle compatibleWithTraitCollection:nil];
     }
   }
 

--- a/ios/SyrNative/SyrNative/SyrRootView.h
+++ b/ios/SyrNative/SyrNative/SyrRootView.h
@@ -11,5 +11,7 @@
 
 @interface SyrRootView : UIView
 @property NSDictionary* appProperties;
+@property (nonatomic)  NSString* resourceBundlePath;
 -(id)initWithBundlePath:(NSString*)bundlePath initialProperties:(NSDictionary*)initialProps;
+-(id) initWithBundlePath:(NSString*)bundlePath initialProperties:(NSDictionary*)initialProps withResourceBundlePath: (NSString*) resourceBundlePath;
 @end

--- a/ios/SyrNative/SyrNative/SyrRootView.m
+++ b/ios/SyrNative/SyrNative/SyrRootView.m
@@ -12,6 +12,7 @@
 @interface SyrRootView()
 @property SyrCore* instance;
 @property NSDictionary* props;
+@property (nonatomic) NSString* resourcePath;
 @end
 
 @implementation SyrRootView
@@ -22,6 +23,10 @@
   if (self!=nil) {
   }
   return self;
+}
+
+-(NSString*) resourceBundlePath{
+  return _resourcePath;
 }
 
 - (NSDictionary*)appProperties {
@@ -44,6 +49,11 @@
     [_instance runApp:bundlePath rootView:self];
   }
   return self;
+}
+
+-(id) initWithBundlePath:(NSString*)bundlePath initialProperties:(NSDictionary*)initialProps withResourceBundlePath: (NSString*) resourceBundlePath {
+  _resourcePath = resourceBundlePath;
+  return [self initWithBundlePath:bundlePath initialProperties:initialProps];
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syr/core",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "minimal react api, that leans toward native SDK developers",
   "main": "index.js",
   "public": true,

--- a/syr.core.podspec
+++ b/syr.core.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'syr.core'
-  s.version          = '1.5.3'
+  s.version          = '1.5.4'
   s.summary          = 'minimally obtrusive reactisque view engine, aimed at native developers'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Syr can now use dynamic paths for JS Bundles, as well as Dynamic paths for Resources on iOS. 

How this works.

`[[SyrRootView alloc] initWithBundlePath:filePath initialProperties:appProps withResourceBundlePath:pyplBundlePath];`

`initWithBundlePath` now works as expected. the path passed to this will be loaded.

`withResourceBundlePath` is new, provide a bundle resource path where assets/images should be loaded. It is still on `component` authors, to ensure they are looking for resources.

Authors should do a fall through like so

```
// check main bundle/xcassets for an image to load
 image = [UIImage imageNamed:source];
// no image loaded, check resourceBundlePath 
 if(image == nil) {
   NSString* resourceBundlePath = [[[SyrRaster sharedInstance] bridge] resourceBundlePath];
   NSBundle* bundle = [[NSBundle alloc] initWithPath:resourceBundlePath];
   image = [UIImage imageNamed:source inBundle:bundle compatibleWithTraitCollection:nil];
 }
```