### PR TITLE
added syr project json property, to specify linked project

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,10 @@
   },
   "dependencies": {
     "@syr/jsx": "^1.0.0"
+  },
+  "syr": {
+    "ios": {
+      "project" : "ios/SyrNative/SyrNative.xcodeproj"
+    }
   }
 }


### PR DESCRIPTION
Added custom Syr properties to package.json. There are multiple project files, this lets `syr-cli` know which project to link.