### PR TITLE
only renders when the component is in the tree

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -31,12 +31,18 @@ class Component {
     // set state
     this.setState = (state, cb) => {
       this.state = merge(this.state, state);
-      // send updated AST to raster
-      this.render ? Render(this) : '';
 
-      if (cb) {
-        cb();
+      // send updated AST to raster
+      // check to see that this instance is available before we attempt to update it
+      if(Render.getInstance(this.uuid)) {
+        this.render ? Render(this) : '';
+        if (cb) {
+          cb();
+        }
+      } else {
+        console.warn('Set state called, while component exited the component tree! >>>', this);
       }
+
     };
   }
 }


### PR DESCRIPTION
modifies so that the component will set the state, in-case a developer is holding a hard reference to it for some reason. But it will alert them that is is no longer in the tree when it attempts to run through Render.