### PR TITLE
Corrects Stackview Auto Height Calc on Update

### DIFF
--- a/ios/SyrNative/SyrNative/SyrStackView.m
+++ b/ios/SyrNative/SyrNative/SyrStackView.m
@@ -58,9 +58,15 @@ SYR_EXPORT_MODULE(StackView)
   if(height != nil && [height isKindOfClass:[NSString class]] && [height containsString:@"auto"]) {
       NSNumber* totalHeight = [NSNumber numberWithInt:0];
       for(id child in [component objectForKey:@"children"]){
-        NSDictionary* childStyle = [SyrStackView determineChildStyle:child];;
-        NSNumber* height = [childStyle objectForKey:@"height"];;
-        totalHeight = [NSNumber numberWithDouble:[totalHeight doubleValue]+[height doubleValue]+[spacing doubleValue]];
+        NSDictionary* childStyle = [SyrStackView determineChildStyle:child];
+        
+        // don't count children moving into unmount into the calculation
+        BOOL unmount = (BOOL)[child valueForKey:@"unmount"];
+        if(!unmount) {
+          NSNumber* height = [childStyle objectForKey:@"height"];
+          totalHeight = [NSNumber numberWithDouble:[totalHeight doubleValue]+[height doubleValue]+[spacing doubleValue]];
+        }
+
       }
     	CGRect frame = stackView.frame;
     	frame.size.height = [totalHeight doubleValue];


### PR DESCRIPTION
Problem.

When rolling through an update state routine, the StackView would mistakenly use `unmounted` children to calculate it's nearest height.

Fix.

Don't do that :) Guard against `unmount`.

@MSiddharthReddy will verify Android