### PR TITLE
Fix Android sample asset bundle URL

### DIFF
--- a/android/app/src/main/java/com/example/dereanderson/syrnativeandroid/MainActivity.java
+++ b/android/app/src/main/java/com/example/dereanderson/syrnativeandroid/MainActivity.java
@@ -67,7 +67,7 @@ public class MainActivity extends AppCompatActivity {
         modules.add(new SyrAlertDialogue());
 
         // get the javascript bundle
-        SyrBundle bundle = new SyrBundleManager().setBundleAssetName("").build();
+        SyrBundle bundle = new SyrBundleManager().setBundleAssetName("http://10.0.2.2:8080").build();
 
         // create an instance of Syr
         SyrInstance instance = new SyrInstanceManager().setJSBundleFile(bundle).build();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request (thanks kent!)

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
### What

Fix bundle URL in Android sample (needed now that GH-238 (PR #238) is merged)

(and add newline)

<!-- Why are these changes necessary? -->

### Why

Now that GH-238 is merged the bundle URL needs to be explicitly specified for Android.

This change is needed to run the sample in `develop` branch on Android as discussed in GH-239 (#239).

<!-- How were these changes implemented? -->
### How

In MainActivity of Android sample do `setBundleAssetName("http://10.0.2.2:8080")` instead of `setBundleAssetName("")`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- Documentation - N/A
- Tests - N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- Added myself to contributors table - N/A