### PR TITLE
Remove obsolete object.observe from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "mocha-coveralls-reporter": "0.0.5",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^11.1.0",
-    "object.observe": "^0.2.6",
     "prettier": "^1.5.3",
     "styled-jsx": "^1.0.10",
     "travis-cov": "^0.2.5",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request (thanks kent!)

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
### What

Remove `object.observe` from `devDependencies` in `package.json`

The one question I have is if  `object.observe` may still be used for documentation build somehow.

<!-- Why are these changes necessary? -->
### Why

- does not seem to be used (still able to run sample)
- get rid of ugly message that `object.observe` is obsolete

<!-- How were these changes implemented? -->
### How

See above

<!-- Have you done all of these things?  -->
### Checklist
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- ~~Documentation~~ (N/A)
- ~~Tests~~ (N/A)
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- ~~Added myself to contributors table~~