### PR TITLE
Remove json-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "html-webpack-plugin": "^2.29.0",
     "html-webpack-template": "^6.1.0",
     "jsdom": "^11.5.1",
-    "json-loader": "^0.5.4",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^11.1.0",


### PR DESCRIPTION
does not seem to be used or needed

`npm run test:jsx` and `npm run test:nodom` continue to pass