### PR TITLE
npm test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ matrix:
       install:
         - npm install
       script:
-        - npm run test:jsx
-        - npm run test:nodom
+        - npm run test
         - npm run build
       env:
         - CXX=g++-4.8

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ if (
 ) {
   RasterManager.setRaster(WKRaster);
 } else {
-  if (typeof window == 'undefined') {
+  if (typeof window == 'undefined' && !global.document) {
     RasterManager.setRaster(NoDOM);
   } else {
     RasterManager.setRaster(DOMRaster);

--- a/test/stackviewtest.js
+++ b/test/stackviewtest.js
@@ -21,13 +21,13 @@ describe('StackView', function() {
 
   it('should have predefined styles', function() {
     assert.equal(element.style['display'], 'flex');
-    assert.equal(element.style['flex-direction'], 'horizontal');
+    assert.equal(element.style['flex-direction'], 'row');
     assert.equal(element.style['align-items'], 'center');
     assert.equal(element.style['justify-content'], 'space-around');
   });
 
   it('should have user-defined orientation (vertical/horizontal)', function() {
-    assert.equal(element.style['flex-direction'], 'horizontal');
+    assert.equal(element.style['flex-direction'], 'row');
   });
 
   it('should have user-defined styles (height & width)', function() {


### PR DESCRIPTION
`npm test` working again on mac and Travis CI

- do not use NoDOM raster in case `global.document` is defined
- update `test/stackviewtest.js`
- do full `npm run test` on Travis CI again

Resolves #266

Open question: I am not sure whether the proposed change to `test/stackviewtest.js` is correct or not. I would generally rather resolve this kind of issue than "sweep it under the rug".