### PR TITLE
enabling use guid, which is required for syr core

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,5 +7,5 @@
       }
     }]
   ],
-  "plugins": [["@syr/jsx", { "useVariables": true }]]
+  "plugins": [["@syr/jsx", { "useVariables": true, "useGuid":true }]]
 }


### PR DESCRIPTION
in a future version of @syr/jsx this is gated.