### PR TITLE
Adding shared preferences & Hash Checking for files before storing them

### DIFF
--- a/android/syrnative/src/main/java/syr/js/org/syrnative/SyrBundleManager.java
+++ b/android/syrnative/src/main/java/syr/js/org/syrnative/SyrBundleManager.java
@@ -188,8 +188,6 @@ public class SyrBundleManager {
 
             try {
 
-                // TODO: Hash Comparision is not working good, need to check this too
-
             if(checkHash(result.getString("file"), result.getString("fileHash"))) {
                 FileOutputStream outputStream = context.openFileOutput(result.getString("fileName"), Context.MODE_PRIVATE);
                 outputStream.write(result.getString("file").getBytes());

--- a/android/syrnative/src/main/java/syr/js/org/syrnative/SyrBundleManager.java
+++ b/android/syrnative/src/main/java/syr/js/org/syrnative/SyrBundleManager.java
@@ -1,6 +1,7 @@
 package syr.js.org.syrnative;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.AsyncTask;
 
 import org.json.JSONArray;
@@ -29,12 +30,17 @@ import java.security.NoSuchAlgorithmException;
 public class SyrBundleManager {
     protected String uri;
     protected Context context;
-    protected String manifestHash = null;
+    protected SharedPreferences sharedPreferences;
+    protected SharedPreferences.Editor editor;
+    private String MANIFEST_DETAILS = "manifestDetails";
+    private String MANIFEST_HASH = "manifestHash";
 
     public SyrBundleManager(Context mContext) {
         // does this need the (additional) config param?
         // if not do we need this constructor?
         context = mContext;
+        sharedPreferences = context.getSharedPreferences(MANIFEST_DETAILS, Context.MODE_PRIVATE);
+        editor = sharedPreferences.edit();
     }
 
     public SyrBundleManager setBundleAssetName(String uri) {
@@ -109,15 +115,20 @@ public class SyrBundleManager {
         @Override
         protected void onPostExecute(String result) {
 
+
+
             try {
                 JSONObject jsonObject = new JSONObject(result);
                 JSONObject manifestObject = jsonObject.getJSONObject("app");
                 String newManifestHash = manifestObject.getString("hash");
                 JSONArray arrJson = manifestObject.getJSONArray("files");
 
+                String manifestHash = sharedPreferences.getString(MANIFEST_HASH,"");
 
-                if(manifestHash == null || manifestHash.equals(newManifestHash)) {
-                    manifestHash = newManifestHash;
+                if(manifestHash == null || !manifestHash.equals(newManifestHash)) {
+
+                    editor.putString(MANIFEST_HASH, newManifestHash);
+                    editor.apply();
                     for(int i = 0; i < arrJson.length(); i++) {
                         JSONObject fileObject = arrJson.getJSONObject(i);
                         String fileType = fileObject.getString("type");
@@ -177,11 +188,12 @@ public class SyrBundleManager {
             try {
 
                 // TODO: Hash Comparision is not working good, need to check this too
-//            if(checkHash(result.getString("file"), result.getString("fileHash"))) {
+
+            if(checkHash(result.getString("file"), result.getString("fileHash"))) {
                 FileOutputStream outputStream = context.openFileOutput(result.getString("fileName"), Context.MODE_PRIVATE);
                 outputStream.write(result.getString("file").getBytes());
                 outputStream.close();
-//            }
+            }
 
             } catch ( JSONException | IOException e) {
                 e.printStackTrace();
@@ -249,7 +261,7 @@ public class SyrBundleManager {
                     hexString.append(h);
                 }
 
-                return hexString.toString() == baseHash;
+                return hexString.toString().equals(baseHash);
 
             } catch (NoSuchAlgorithmException e) {
                 e.printStackTrace();

--- a/android/syrnative/src/main/java/syr/js/org/syrnative/SyrBundleManager.java
+++ b/android/syrnative/src/main/java/syr/js/org/syrnative/SyrBundleManager.java
@@ -123,9 +123,10 @@ public class SyrBundleManager {
                 String newManifestHash = manifestObject.getString("hash");
                 JSONArray arrJson = manifestObject.getJSONArray("files");
 
+                // TODO: This will be used to store the whole manifest in the future.
                 String manifestHash = sharedPreferences.getString(MANIFEST_HASH,"");
 
-                if(manifestHash == null || !manifestHash.equals(newManifestHash)) {
+                if(!manifestHash.equals(newManifestHash)) {
 
                     editor.putString(MANIFEST_HASH, newManifestHash);
                     editor.apply();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request (thanks kent!)

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
* Adding Hash checking for files before storing them to the internal Storage.
* Storing Manifest Hash in the shared preferences to persist it even when the app closes. ( We can use this to store the whole manifest in the future)

<!-- Why are these changes necessary? -->
**Why**:
* Persist Manifest data between app closes.
* Store the files if we get a complete file and the same one sent from the OTA.

<!-- How were these changes implemented? -->
**How**:
* Changes to SYRBundleManager

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
