### PR TITLE
Fixed Broken Android CI by updating SDK version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         components:
           - platform-tools
           - tools
-          - build-tools-26.0.2
+          - build-tools-28.0.3
           - android-22
           - sys-img-armeabi-v7a-android-22 # we are using a api 22 image to run our tests for now
           - extra-android-m2repository

--- a/android/app/src/main/java/com/example/dereanderson/syrnativeandroid/MainActivity.java
+++ b/android/app/src/main/java/com/example/dereanderson/syrnativeandroid/MainActivity.java
@@ -67,7 +67,7 @@ public class MainActivity extends AppCompatActivity {
         modules.add(new SyrAlertDialogue());
 
         // get the javascript bundle
-        SyrBundle bundle = new SyrBundleManager().setBundleAssetName("http://10.0.2.2:8080").build();
+        SyrBundle bundle = new SyrBundleManager(this).setBundleAssetName("http://10.0.2.2:8080").build();
 
         // create an instance of Syr
         SyrInstance instance = new SyrInstanceManager().setJSBundleFile(bundle).build();


### PR DESCRIPTION
**What**:
Fixed Broken Android CI
**Why**:
Every PR CI job fails since Android CI is failing due to failure of SDK license acceptance.
**How**:
Android SDK version is updated to 28.0.3 in .travis.yml since `Travis` uses 28.0.3 Android SDK during CI build.
Personal Green CI job link - https://travis-ci.org/harishannam/core/jobs/496948314

**Checklist**:
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->